### PR TITLE
Convert example into executable module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ COPY templates /app/templates/
 # Run the app when the container starts.
 WORKDIR /app/
 ENV PYTHONPATH /app/
-CMD ["python", "/app/hello_genomics/main.py"]
+CMD ["python", "-m", "hello_genomics"]

--- a/hello_genomics/__main__.py
+++ b/hello_genomics/__main__.py
@@ -1,0 +1,3 @@
+from .main import main
+
+main()

--- a/hello_genomics/main.py
+++ b/hello_genomics/main.py
@@ -12,7 +12,7 @@ import logging
 
 from collections import defaultdict
 from fastgenomics import io as fg_io
-from hello_genomics import logging_config
+from . import logging_config
 
 # initialize logging
 logging_config.configure_logging(level=logging.INFO)
@@ -127,7 +127,3 @@ def main():
         f_sum.write(summary)
 
     logger.info("Done.")
-
-
-if __name__ == '__main__':
-    main()


### PR DESCRIPTION
In Python, modules with a clear entry point should be executable via `python -m mymodule` instead of having a script like `python mymodule/main.py`.